### PR TITLE
Fix typo

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,21 +13,21 @@ const ObjectId = mongoose.Schema.ObjectId;
 /**
  * getPaths(model)
  *
- * Extracts all paths and defintion from mongoose schema
+ * Extracts all paths and definition from mongoose schema
  *
- * @param {MongooseSchmea} model The model schema object
+ * @param {MongooseSchema} model The model schema object
  *
  * Returns an object for paths definition with the following format:
  * {
  *   <path name>: <path description>
  * }
- * where path descrtiption is in the following format:
+ * where path description is in the following format:
  * {
  *  required: Boolean <this path is required>,
  *  validators: Array <defined validation functions>,
  *  default: Mixed <default path value>,
  *  isEnum: Boolean <if path only accepts enumerations>,
- *  enum: Array <path enumration if isEnum>,
+ *  enum: Array <path enumeration if isEnum>,
  *  isPathDef: Boolean <if it is a path definition object>,
  *  lowercase: Boolean <lowercase filter>,
  *  uppercase: Boolean <uppercase filter>,
@@ -189,13 +189,13 @@ let generateRandomModel = (paths, opts) => {
         }
         if (opts.custom.address) {
             if (typeof opts.custom.address === "string") {
-                customAddres = [opts.custom.address]
+                customAddress = [opts.custom.address]
             } else if (Array.isArray(opts.custom.address)) {
-                customAddres = opts.custom.address
+                customAddress = opts.custom.address
             } else if (typeof opts.custom.address === "object") {
-                customAddres = opts.custom.address.field;
-                if (typeof customAddres === "string") {
-                    customAddres = [customAddres];
+                customAddress = opts.custom.address.field;
+                if (typeof customAddress === "string") {
+                    customAddress = [customAddress];
                 }
                 if (opts.custom.address.value) {
                     addressGenerator = opts.custom.address.value;
@@ -347,7 +347,7 @@ let generateRandomModel = (paths, opts) => {
  *
  * Extracts all paths using getPaths() then generate random object from these paths
  *
- * @param {MongooseSchmea} model The model schema object
+ * @param {MongooseSchema} model The model schema object
  * @param {Object} opts Options object passed to generateRandomModel()
  *
  * Returns the generated dummy object


### PR DESCRIPTION
- Typo in documentation
- Typo in variable name `customAddres` -> `customAddress`